### PR TITLE
fix: use GITHUB_TOKEN instead of GITHUB_ACCESS_TOKEN

### DIFF
--- a/internal/changelog/config.go
+++ b/internal/changelog/config.go
@@ -149,7 +149,7 @@ func (c *Config) GetGitHubRepository() (string, string, error) {
 
 // Get GITHUB_ACCESSS_TOKEN from environment, returns empty string otherwise.
 func (c *Config) GetGitHubAccessToken() string {
-	if envStr, ok := os.LookupEnv("GITHUB_ACCESS_TOKEN"); ok {
+	if envStr, ok := os.LookupEnv("GITHUB_TOKEN"); ok {
 		return envStr
 	}
 	return ""


### PR DESCRIPTION
CI uses GITHUB_TOKEN very frequently, it saves the amount of effort of duplicating the logic.